### PR TITLE
fix CORS handling for OPTIONS method

### DIFF
--- a/examples/next-js/src/app/api/actions/memo/route.ts
+++ b/examples/next-js/src/app/api/actions/memo/route.ts
@@ -34,7 +34,9 @@ export const GET = async (req: Request) => {
 
 // DO NOT FORGET TO INCLUDE THE `OPTIONS` HTTP METHOD
 // THIS WILL ENSURE CORS WORKS FOR BLINKS
-export const OPTIONS = GET;
+export const OPTIONS = async (req: Request) => {
+  return new Response(null, { headers: ACTIONS_CORS_HEADERS });
+};
 
 export const POST = async (req: Request) => {
   try {

--- a/examples/next-js/src/app/api/actions/stake/route.ts
+++ b/examples/next-js/src/app/api/actions/stake/route.ts
@@ -82,7 +82,9 @@ export const GET = async (req: Request) => {
 
 // DO NOT FORGET TO INCLUDE THE `OPTIONS` HTTP METHOD
 // THIS WILL ENSURE CORS WORKS FOR BLINKS
-export const OPTIONS = GET;
+export const OPTIONS = async (req: Request) => {
+  return new Response(null, { headers: ACTIONS_CORS_HEADERS });
+};
 
 export const POST = async (req: Request) => {
   try {

--- a/examples/next-js/src/app/api/actions/transfer-sol/route.ts
+++ b/examples/next-js/src/app/api/actions/transfer-sol/route.ts
@@ -79,7 +79,9 @@ export const GET = async (req: Request) => {
 
 // DO NOT FORGET TO INCLUDE THE `OPTIONS` HTTP METHOD
 // THIS WILL ENSURE CORS WORKS FOR BLINKS
-export const OPTIONS = GET;
+export const OPTIONS = async (req: Request) => {
+  return new Response(null, { headers: ACTIONS_CORS_HEADERS });
+};
 
 export const POST = async (req: Request) => {
   try {


### PR DESCRIPTION
Updated the `OPTIONS` method to improve the handling of CORS preflight requests: 

- Changed `OPTIONS` method to return a response with CORS headers only, avoiding unnecessary processing.
- Fixes the 405 error caused by reusing `GET` method logic for image resources in `OPTIONS` requests..