### PR TITLE
[spec] v2.2 - action chaining

### DIFF
--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -164,12 +164,9 @@ export type ActionType = "action" | "completed";
 
 export type ActionGetResponse = Action<"action">;
 
-/**
- * A single Solana Action
- */
 export interface Action<T extends ActionType = "action"> {
-  /** @default `action` */
-  type?: T;
+  /** type of Action to present to the user */
+  type: T;
   /** image url that represents the source of the action request */
   icon: string;
   /** describes the source of the action request */
@@ -228,7 +225,7 @@ export interface Action<T extends ActionType = "action"> {
 
 ```ts filename="ActionError"
 export interface ActionError {
-  /** non-fatal error message to be displayed to the user */
+  /** simple error message to be displayed to the user */
   message: string;
 }
 ```
@@ -560,9 +557,7 @@ To chain multiple actions together, in any `ActionPostResponse` include a
 ```ts filename="NextActionLink"
 export type NextActionLink = PostNextActionLink | InlineNextActionLink;
 
-/**
- * @see {NextActionPostRequest}
- */
+/** @see {NextActionPostRequest} */
 export interface PostNextActionLink {
   /** Indicates the type of the link. */
   type: "post";

--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -485,8 +485,8 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
   discount applied to a purchase, or a thank you note.
 
 - `links.next` - An optional value use to "chain" multiple Actions together in
-  series. After the included `transaction` has been confirm on-chain, this
-  `links.next` can be used to fetch the next action. See
+  series. After the included `transaction` has been confirmed on-chain, the
+  client can fetch and render the next action. See
   [Action Chaining](#action-chaining) for more details.
 
 - The client and application should allow additional fields in the request body
@@ -534,7 +534,7 @@ Solana Actions can be "chained" together in a successive series. After an
 Action's transaction is confirmed on-chain, the next action can be obtained and
 presented to the user.
 
-Action chaining allows developer to build more complex and dynamic experiences
+Action chaining allows developers to build more complex and dynamic experiences
 within blinks, including:
 
 - providing multiple transactions (and eventually sign message) to a user
@@ -542,7 +542,8 @@ within blinks, including:
 - refreshing the blink metadata after a successful transaction
 - receive an API callback with the transaction signature for additional
   validation and logic on the Action API server
-- customized "success" messages with updated action metadata
+- customized "success" messages by updating the displayed metadata (e.g. a new
+  image and description)
 
 To chain multiple actions together, in any `ActionPostResponse` include a
 `links.next` of either:
@@ -576,6 +577,8 @@ export interface InlineNextActionLink {
 }
 ```
 
+##### NextAction
+
 After the `ActionPostResponse` included `transaction` is signed by the user and
 confirmed on-chain, the blink client should either:
 
@@ -595,16 +598,16 @@ export type NextAction = Action<"action"> | CompletedAction;
 export type CompletedAction = Omit<Action<"completed">, "links">;
 ```
 
-A `NextAction` should be presented to the user via blink clients in one of two
-ways, based on the `type`:
+Based on the `type`, the next action should be presented to the user via blink
+clients in one of the following ways:
 
 - `action` - (default) A standard action that will allow the user to see the
   included Action metadata, interact with the provided `LinkedActions`, and
   continue to chain any following actions.
 
 - `completed` - The terminal state of an action chain that can update the blink
-  UI with the included Action metadata to the user, but will not allow the user
-  to execute further actions.
+  UI with the included Action metadata, but will not allow the user to execute
+  further actions.
 
 If no `links.next` is not provided, blink clients should assume the current
 action is final action in the chain, presenting their "completed" UI state after

--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -177,7 +177,6 @@ export interface Action<T extends ActionType = "action"> {
   label: string;
   /** UI state for the button being rendered to the user */
   disabled?: boolean;
-  /**  */
   links?: {
     /** list of related Actions a user could perform */
     actions: LinkedAction[];

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -49,14 +49,17 @@ export type ActionType = "action" | "completed";
 /**
  * Response body payload returned from the initial Action GET Request
  */
-export type ActionGetResponse = Action<"action">;
+export interface ActionGetResponse extends Omit<Action, "type"> {
+  type?: "action";
+}
 
 /**
  * A single Solana Action
  */
 export interface Action<T extends ActionType = "action"> {
   /** @default `action` */
-  type?: T;
+  /** type of Action to present to the user */
+  type: T;
   /** image url that represents the source of the action request */
   icon: string;
   /** describes the source of the action request */
@@ -194,7 +197,7 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
      *    - and should respond with a `NextAction`
      * @param `NextAction` - the metadata for the next action to render upon transaction confirmation
      */
-    next: string | NextAction<T | "action">;
+    next: string | NextAction<T>;
   };
 }
 

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -189,7 +189,8 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
   message?: string;
   links?: {
     /**
-     * The next action in a successive chain of actions to be obtained after the previous was successful.
+     * The next action in a successive chain of actions to be obtained after
+     * the previous was successful.
      */
     next: NextActionLink;
   };

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -47,13 +47,15 @@ export interface ActionGetRequest {}
 export type ActionType = "action" | "completed";
 
 /**
+ * Response body payload returned from the initial Action GET Request
+ */
+export type ActionGetResponse = Action<"action">;
+
+/**
  * A single Solana Action
  */
 export interface Action<T extends ActionType = "action"> {
-  /**
-   * action type to
-   * @default `action`
-   */
+  /** @default `action` */
   type?: T;
   /** image url that represents the source of the action request */
   icon: string;
@@ -73,11 +75,6 @@ export interface Action<T extends ActionType = "action"> {
   /** non-fatal error message to be displayed to the user */
   error?: ActionError;
 }
-
-/**
- * Response body payload returned from the initial Action GET Request
- */
-export type ActionGetResponse = Action<"action">;
 
 /**
  * Related action on a single endpoint
@@ -180,14 +177,6 @@ export interface ActionPostRequest<T = string> {
 }
 
 /**
- * The next action to be presented to the user after the previous action was successful
- * (i.e. after the transaction was confirmed on-chain)
- */
-export type NextAction<T extends ActionType> = T extends "completed"
-  ? Omit<Action<T>, "links">
-  : Action<T>;
-
-/**
  * Response body payload returned from the Action POST Request
  */
 export interface ActionPostResponse<T extends ActionType = ActionType> {
@@ -208,6 +197,14 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
     next: string | NextAction<T | "action">;
   };
 }
+
+/**
+ * The next action to be presented to the user after the previous action was successful
+ * (i.e. after the transaction was confirmed on-chain)
+ */
+export type NextAction<T extends ActionType> = T extends "completed"
+  ? Omit<Action<T>, "links">
+  : Action<T>;
 
 /**
  * Response body payload sent via POST request to obtain the next action

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -57,7 +57,6 @@ export interface ActionGetResponse extends Omit<Action, "type"> {
  * A single Solana Action
  */
 export interface Action<T extends ActionType = "action"> {
-  /** @default `action` */
   /** type of Action to present to the user */
   type: T;
   /** image url that represents the source of the action request */
@@ -253,6 +252,6 @@ export interface NextActionPostRequest extends ActionPostRequest {
  * Error message that can be returned from an Actions API
  */
 export interface ActionError {
-  /**  */
+  /** simple error message to be displayed to the user */
   message: string;
 }

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -69,7 +69,6 @@ export interface Action<T extends ActionType = "action"> {
   label: string;
   /** UI state for the button being rendered to the user */
   disabled?: boolean;
-  /**  */
   links?: {
     /** list of related Actions a user could perform */
     actions: LinkedAction[];

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -126,8 +126,8 @@ export interface ActionParameter<T extends ActionParameterType, M = MinMax<T>> {
 type MinMax<T extends ActionParameterType> = T extends "date" | "datetime-local"
   ? string
   : T extends "radio" | "select"
-    ? never
-    : number;
+  ? never
+  : number;
 
 type GeneralParameterType =
   | "text"
@@ -199,8 +199,8 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
  * Represents a link to the next action to be performed.
  * The next action can be either a POST request to a callback URL or an inline action.
  *
- * @see PostNextActionLink
- * @see InlineNextActionLink
+ * @see {@link PostNextActionLink}
+ * @see {@link InlineNextActionLink}
  */
 export type NextActionLink = PostNextActionLink | InlineNextActionLink;
 
@@ -210,6 +210,9 @@ export type NextActionLink = PostNextActionLink | InlineNextActionLink;
  * This is a same origin callback URL used to fetch the next action in the chain.
  * - This callback URL will receive a POST request with a body of `NextActionPostRequest`.
  * - It should respond with a `NextAction`.
+ *
+ * @see {@link NextAction}
+ * @see {@link NextActionPostRequest}
  */
 export interface PostNextActionLink {
   /** Indicates the type of the link. */
@@ -249,6 +252,6 @@ export interface NextActionPostRequest extends ActionPostRequest {
  * Error message that can be returned from an Actions API
  */
 export interface ActionError {
-  /** non-fatal error message to be displayed to the user */
+  /**  */
   message: string;
 }


### PR DESCRIPTION
## TLDR

Actions can be chained together in successive series up to a depth of `n`. Each action can provide a callback url to fetch the next action in the series (being provided the `signature` from the previous action`) which can then be presented to users via action aware clients.

Action chaining allows developer to build more complex and dynamic experiences within blinks, including:

- providing multiple transactions (and eventually sign message) to a user
- customized action metadata based on the user's wallet address
- refreshing the blink metadata after a successful transaction
- receive an API callback with the transaction signature for additional
  validation and logic on the Action API server

## Rationale

Blinks and actions are currently limited to a single depth of interaction. After the user signs a transaction, it concludes the experience. Action chaining allows developers to provide a depth of `n` actions, creating more dynamic and comprehensive experiences.

sRFC: https://forum.solana.com/t/srfc-28-blinks-chaining/1734 