### PR TITLE
Update CORS headers based on compatibility sRFC

### DIFF
--- a/packages/solana-actions/src/constants.ts
+++ b/packages/solana-actions/src/constants.ts
@@ -35,6 +35,7 @@ export const ACTIONS_CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Methods": "GET,POST,PUT,OPTIONS",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Content-Encoding, Accept-Encoding, X-Action-Version, X-Blockchain-Ids",
+  "Access-Control-Expose-Headers": "X-Action-Version, X-Blockchain-Ids",
   "Content-Type": "application/json",
 };
 
@@ -53,6 +54,10 @@ export const ACTIONS_CORS_HEADERS_MIDDLEWARE = {
     "Authorization",
     "Content-Encoding",
     "Accept-Encoding",
+    "X-Action-Version",
+    "X-Blockchain-Ids",
+  ],
+  exposedHeaders: [
     "X-Action-Version",
     "X-Blockchain-Ids",
   ],

--- a/packages/solana-actions/src/constants.ts
+++ b/packages/solana-actions/src/constants.ts
@@ -34,7 +34,7 @@ export const ACTIONS_CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET,POST,PUT,OPTIONS",
   "Access-Control-Allow-Headers":
-    "Content-Type, Authorization, Content-Encoding, Accept-Encoding, X-Action-Version, X-Blockchain-Ids",
+    "Content-Type, Authorization, Content-Encoding, Accept-Encoding, X-Accept-Action-Version, X-Accept-Blockchain-Ids",
   "Access-Control-Expose-Headers": "X-Action-Version, X-Blockchain-Ids",
   "Content-Type": "application/json",
 };
@@ -54,8 +54,8 @@ export const ACTIONS_CORS_HEADERS_MIDDLEWARE = {
     "Authorization",
     "Content-Encoding",
     "Accept-Encoding",
-    "X-Action-Version",
-    "X-Blockchain-Ids",
+    "X-Accept-Action-Version",
+    "X-Accept-Blockchain-Ids",
   ],
   exposedHeaders: [
     "X-Action-Version",


### PR DESCRIPTION
**Context & Problem**

Based on sRFC https://forum.solana.com/t/srfc-31-compatibility-of-blinks-and-actions/1892

> Response headers are proposed to be set by Action developers:
- `X-Action-Version` to show what spec version the action API server is using
- `X-Blockchain-Ids` to list blockchains the action supports.
> In the future request headers are proposed to be set by Blink clients:
- `X-Accept-Action-Version` to show the max spec version the Blink client supports.
- `X-Accept-Blockchain-Ids` to list blockchains the client supports.

Wallets cannot get custom response headers like `X-Action-Version` and `X-Blockchain-Ids `  by default: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers

**Solution**

1. Add `Access-Control-Expose-Headers: X-Blockchain-Ids, X-Action-Version` to make compatibility metadata available to scripts running in the browser. 
2. Update `Access-Control-Allow-Headers` to include `X-Accept-Action-Version` and `X-Accept-Blockchain-Ids` as a preparation step to support client request headers in the future.