### PR TITLE
Fix Regex Pattern to Correctly Match Hyphenated Strings in Identifier Parsing"

### DIFF
--- a/packages/solana-actions/src/actionIdentity.ts
+++ b/packages/solana-actions/src/actionIdentity.ts
@@ -73,7 +73,7 @@ export function validateActionIdentifierMemo(
         memo = memo.match(/^\[\d+\] (.*)/)?.[1].trim() || memo;
       }
 
-      if (/^([\w\d]+:){2,}/g.test(memo) == false) {
+      if (/^([\w\d\-]+:){2,}/g.test(memo) == false) {
         throw new ActionIdentifierError("invalid memo formatting");
       }
 


### PR DESCRIPTION
This PR fixes an issue with the regex pattern used for identifier parsing, where the original regex `^([\w\d]+:){2,}` failed to match strings containing hyphens (e.g., solana-action:). The updated regex `^([\w\d\-]+:){2,}` now correctly accounts for hyphenated strings by including hyphens in the character class. 

Solves: #24 