### PR TITLE
[spec] sign message - missing type and docs

### DIFF
--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -750,9 +750,11 @@ value and prompted to sign it with their wallet to generate a `signature`.
 
 The `data` can be a plaintext string or a structured `SignMessageData` object.
 
-When using `SignMessageData`, it must be formatted as a standardized, human-readable plaintext suitable for signing. 
-Both the client and server must generate the message using the same method to ensure proper verification.
-The following template must be used by both the Action API and the client to format `SignMessageData`:
+When using `SignMessageData`, it must be formatted as a standardized,
+human-readable plaintext suitable for signing. Both the client and server must
+generate the message using the same method to ensure proper verification. The
+following template must be used by both the Action API and the client to format
+`SignMessageData`:
 
 ```
 ${domain} wants you to sign a message with your account:
@@ -765,12 +767,16 @@ Nonce: ${nonce}
 Issued At: ${issuedAt}
 ```
 
-If `chainId` is not provided, the `Chain ID` line should be omitted from the message to be signed.
+If `chainId` is not provided, the `Chain ID` line should be omitted from the
+message to be signed.
 
-Client should not prefix, suffix or otherwise modify the `SignMessageData` value before signing it.
-Client should perform validation on the `SignMessageData` before signing to ensure that it meets expected criteria and to prevent potential security issues.
+Client should not prefix, suffix or otherwise modify the `SignMessageData` value
+before signing it. Client should perform validation on the `SignMessageData`
+before signing to ensure that it meets expected criteria and to prevent
+potential security issues.
 
-The following function illustrates how to create a human-readable message text from `SignMessageData`:
+The following function illustrates how to create a human-readable message text
+from `SignMessageData`:
 
 ```ts
 export function createSignMessageText(input: SignMessageData): string {
@@ -791,13 +797,16 @@ export function createSignMessageText(input: SignMessageData): string {
 ```
 
 After signing, the blink client will continue the chain-of-actions by making a
-POST request to the provided `PostNextActionLink` endpoint with a payload
-similar to the normal `ActionPostRequest` fields (see
-[Action Chaining](#action-chaining)), but with the additional fields:
+POST request to the provided `PostNextActionLink` endpoint with a payload of
+`SignMessagePostRequest`. This payload similar to the normal `ActionPostRequest`
+fields (see [Action Chaining](#action-chaining)), but with the additional
+fields:
 
 - `signature` (required) - the signature created by the account singing the data
   (as a base58 encoded string)
-- `state` (optional) - the same unmodified `state` value the action api initial
+- `data` (required) - the same unmodified `data` value the Action api initial
+  provided, relayed back from the client.
+- `state` (optional) - the same unmodified `state` value the Action api initial
   provided, relayed back from the client.
 
 ### Action Errors

--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -804,10 +804,10 @@ fields:
 
 - `signature` (required) - the signature created by the account singing the data
   (as a base58 encoded string)
-- `data` (required) - the same unmodified `data` value the Action api initial
+- `data` (required) - the same unmodified `data` value the Action api initially
   provided, relayed back from the client.
-- `state` (optional) - the same unmodified `state` value the Action api initial
-  provided, relayed back from the client.
+- `state` (optional) - the same unmodified `state` value the Action api
+  initially provided, relayed back from the client.
 
 ### Action Errors
 

--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -798,7 +798,7 @@ export function createSignMessageText(input: SignMessageData): string {
 
 After signing, the blink client will continue the chain-of-actions by making a
 POST request to the provided `PostNextActionLink` endpoint with a payload of
-`SignMessagePostRequest`. This payload is similar to the normal
+`MessageNextActionPostRequest`. This payload is similar to the normal
 `ActionPostRequest` fields (see [Action Chaining](#action-chaining)), but with
 the following modifications:
 

--- a/packages/actions-spec/README.md
+++ b/packages/actions-spec/README.md
@@ -798,9 +798,9 @@ export function createSignMessageText(input: SignMessageData): string {
 
 After signing, the blink client will continue the chain-of-actions by making a
 POST request to the provided `PostNextActionLink` endpoint with a payload of
-`SignMessagePostRequest`. This payload similar to the normal `ActionPostRequest`
-fields (see [Action Chaining](#action-chaining)), but with the additional
-fields:
+`SignMessagePostRequest`. This payload is similar to the normal
+`ActionPostRequest` fields (see [Action Chaining](#action-chaining)), but with
+the following modifications:
 
 - `signature` (required) - the signature created by the account singing the data
   (as a base58 encoded string)

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -276,7 +276,6 @@ export type NextAction = Action<"action"> | CompletedAction;
  *
  * @see {@link NextAction} should be returned as the POST response
  */
-
 export interface NextActionPostRequest extends Omit<ActionPostRequest, "type"> {
   /** signature produced from the previous action (either a transaction id or message signature) */
   signature?: string;
@@ -332,6 +331,22 @@ export type ActionPostResponse =
   | PostResponse
   | ExternalLinkResponse
   | SignMessageResponse;
+
+/**
+ * Response body payload sent via POST request (after performing a "sign message" action)
+ * to obtain the next action in a successive chain of actions
+ *
+ * @see {@link NextAction} should be returned as the POST response
+ */
+export interface SignMessagePostRequest
+  extends Omit<NextActionPostRequest, "data"> {
+  /** signature produced from the previous action's message signing request */
+  signature: string;
+  /** unedited `data` value initially provided by the Action API, relayed back to the Action API */
+  data: SignMessageResponse["data"];
+  /** unedited `state` value initially provided by the Action API, relayed back to the Action API */
+  state?: SignMessageResponse["state"];
+}
 
 /**
  * Error message that can be returned from an Actions API

--- a/packages/actions-spec/index.d.ts
+++ b/packages/actions-spec/index.d.ts
@@ -333,12 +333,12 @@ export type ActionPostResponse =
   | SignMessageResponse;
 
 /**
- * Response body payload sent via POST request (after performing a "sign message" action)
+ * Request body payload sent via POST request (after performing a "sign message" action)
  * to obtain the next action in a successive chain of actions
  *
  * @see {@link NextAction} should be returned as the POST response
  */
-export interface SignMessagePostRequest
+export interface MessageNextActionPostRequest
   extends Omit<NextActionPostRequest, "data"> {
   /** signature produced from the previous action's message signing request */
   signature: string;


### PR DESCRIPTION
added the missing type of `SignMessagePostRequest` and the missing docs details for the required `data` field