### PR TITLE
Remove deceptive unknown

### DIFF
--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -137,7 +137,7 @@ async function postTransferSol(req, res) {
 
     res.json(payload);
   } catch (err) {
-    res.status(400).json({ error: err.message || "An unknown error occurred" });
+    res.status(400).json({ error: err.message || "An undescribed error occurred" });
   }
 }
 

--- a/examples/next-js/src/app/api/actions/chaining-basics/next-action/route.ts
+++ b/examples/next-js/src/app/api/actions/chaining-basics/next-action/route.ts
@@ -132,7 +132,7 @@ export const POST = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,

--- a/examples/next-js/src/app/api/actions/chaining-basics/route.ts
+++ b/examples/next-js/src/app/api/actions/chaining-basics/route.ts
@@ -141,7 +141,7 @@ export const POST = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,

--- a/examples/next-js/src/app/api/actions/memo/route.ts
+++ b/examples/next-js/src/app/api/actions/memo/route.ts
@@ -89,7 +89,7 @@ export const POST = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,

--- a/examples/next-js/src/app/api/actions/stake/route.ts
+++ b/examples/next-js/src/app/api/actions/stake/route.ts
@@ -75,7 +75,7 @@ export const GET = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,
@@ -152,7 +152,7 @@ export const POST = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,

--- a/examples/next-js/src/app/api/actions/transfer-sol/route.ts
+++ b/examples/next-js/src/app/api/actions/transfer-sol/route.ts
@@ -73,7 +73,7 @@ export const GET = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,
@@ -155,7 +155,7 @@ export const POST = async (req: Request) => {
     });
   } catch (err) {
     console.log(err);
-    let actionError: ActionError = { message: "An unknown error occurred" };
+    let actionError: ActionError = { message: "An error occurred" };
     if (typeof err == "string") actionError.message = err;
     return Response.json(actionError, {
       status: 400,


### PR DESCRIPTION
This was so much of a distraction for me that, wow, I've distracted myself further by making this PR.

The word, "unknown" in this message is at best unneeded and at worst deceptive. The error is almost certainly known. It was passed to the catch. We could figure it out. We could code to it. What we're doing is punting, because writing a bunch of error detecting code would be a distraction here. So, let's be honest about it. An error occurred. It is not unknown. We're simply punting it out.