### PR TITLE
Point at client only with reason

### DIFF
--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -137,7 +137,7 @@ async function postTransferSol(req, res) {
 
     res.json(payload);
   } catch (err) {
-    res.status(400).json({ error: err.message || "An unknown error occurred" });
+    res.status(500).json({ error: err.message || "An unknown error occurred" });
   }
 }
 

--- a/examples/next-js/src/app/api/actions/chaining-basics/next-action/route.ts
+++ b/examples/next-js/src/app/api/actions/chaining-basics/next-action/route.ts
@@ -133,9 +133,13 @@ export const POST = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }

--- a/examples/next-js/src/app/api/actions/chaining-basics/route.ts
+++ b/examples/next-js/src/app/api/actions/chaining-basics/route.ts
@@ -142,9 +142,13 @@ export const POST = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }

--- a/examples/next-js/src/app/api/actions/memo/route.ts
+++ b/examples/next-js/src/app/api/actions/memo/route.ts
@@ -90,9 +90,13 @@ export const POST = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }

--- a/examples/next-js/src/app/api/actions/stake/route.ts
+++ b/examples/next-js/src/app/api/actions/stake/route.ts
@@ -76,9 +76,13 @@ export const GET = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }

--- a/examples/next-js/src/app/api/actions/transfer-sol/route.ts
+++ b/examples/next-js/src/app/api/actions/transfer-sol/route.ts
@@ -74,9 +74,13 @@ export const GET = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }
@@ -156,9 +160,13 @@ export const POST = async (req: Request) => {
   } catch (err) {
     console.log(err);
     let actionError: ActionError = { message: "An unknown error occurred" };
-    if (typeof err == "string") actionError.message = err;
+    let status = 500;
+    if (typeof err == "string") {
+      actionError.message = err;
+      status = 400;
+    }
     return Response.json(actionError, {
-      status: 400,
+      status: status,
       headers,
     });
   }


### PR DESCRIPTION
Let's be friendly and helpful. Let's not point at the client without reason.
Here we return 400 provided we've examined the request, found fault, and thrown a message. Otherwise, we are honest, friendly and credible. Not having examined the fault, we accept responsibility using 500.